### PR TITLE
feat: post-quantum handshake (ML-KEM-1024 + ML-DSA-87)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,89 @@
+name: Docker GHCR Publish
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]*'
+
+permissions:
+  packages: write
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: disentangle-network/nebula-pq
+
+jobs:
+  build-binaries:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          make BUILD_NUMBER="${GITHUB_REF#refs/tags/v}" \
+            build/${{ matrix.goos }}-${{ matrix.goarch }}/nebula \
+            build/${{ matrix.goos }}-${{ matrix.goarch }}/nebula-cert
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: build/${{ matrix.goos }}-${{ matrix.goarch }}/
+
+  push-image:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download amd64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-linux-amd64
+          path: build/linux-amd64/
+
+      - name: Download arm64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-linux-arm64
+          path: build/linux-arm64/
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build and push multi-arch
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Nebula-PQ
+
+[![Build and test](https://github.com/disentangle-network/nebula-pq/actions/workflows/test.yml/badge.svg)](https://github.com/disentangle-network/nebula-pq/actions/workflows/test.yml)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+**Post-quantum fork of [Nebula](https://github.com/slackhq/nebula)** with hybrid X25519 + ML-KEM-1024 key exchange and ML-DSA-87 certificate support. Drop-in replacement — all existing Nebula configurations work unchanged; PQ curves activate only when explicitly configured.
+
+### PQ Additions
+- Hybrid handshake: X25519 classical + ML-KEM-1024 post-quantum key encapsulation
+- ML-DSA-87 certificate authority and node certificates via `nebula-cert`
+- Backward-compatible: classical and PQ nodes can coexist on the same mesh
+- Multi-arch Docker image: `ghcr.io/disentangle-network/nebula-pq`
+
+---
+
 ## What is Nebula?
 Nebula is a scalable overlay networking tool with a focus on performance, simplicity and security.
 It lets you seamlessly connect computers anywhere in the world. Nebula is portable, and runs on Linux, OSX, Windows, iOS, and Android.


### PR DESCRIPTION
## Post-Quantum Nebula

Hybrid X25519 + ML-KEM-1024 key exchange and ML-DSA-87 certificate support for Nebula.

### Changes
- Hybrid handshake: classical X25519 + ML-KEM-1024 post-quantum key encapsulation
- `nebula-cert`: PQ curve support for CA and node certificate generation
- PKI integration: PQ certificates loaded and verified alongside classical
- E2E handshake test validating full PQ key exchange
- GHCR multi-arch Docker publish workflow (linux/amd64 + linux/arm64)
- README: badges, PQ description

### Backward Compatibility
All existing Nebula configurations work unchanged. PQ curves activate only when `curve: pq` is specified in config. Classical and PQ nodes can coexist on the same mesh.

### Testing
- All existing tests pass (gofmt, smoke, build-and-test)
- New e2e handshake test for PQ curve
- Help text tests updated for new curve options