### PR TITLE
fix: add contents write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 
 name: Create release and upload binaries
 
+permissions:
+  contents: write
+
 jobs:
   build-linux:
     name: Build Linux/BSD All


### PR DESCRIPTION
The release workflow failed on v1.11.0-pq.1 with HTTP 403 because it lacked permissions to create releases. This adds the required permissions block.