### PR TITLE
build: align Go version across workflows, use go-version-file

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -18,8 +18,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: Install goimports
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
-          check-latest: true
+          go-version-file: 'go.mod'
 
       - name: Build
         run: |
@@ -40,8 +39,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
-          check-latest: true
+          go-version-file: 'go.mod'
 
       - name: Build
         run: |
@@ -73,8 +71,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
-          check-latest: true
+          go-version-file: 'go.mod'
 
       - name: Import certificates
         if: env.HAS_SIGNING_CREDS == 'true'

--- a/.github/workflows/smoke-extra.yml
+++ b/.github/workflows/smoke-extra.yml
@@ -24,8 +24,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: add hashicorp source
       run: wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,8 +22,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: build
       run: make bin-docker CGO_ENABLED=1 BUILD_ARGS=-race

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: Build
       run: make all
@@ -60,8 +59,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: Build
       run: make bin-boringcrypto
@@ -81,8 +79,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: Build
       run: make bin-pkcs11
@@ -102,8 +99,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        check-latest: true
+        go-version-file: 'go.mod'
 
     - name: Build nebula
       run: go build ./cmd/nebula

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "golang": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replace all hardcoded `go-version: '1.23'` / `go-version: '1.25'` in every `actions/setup-go` step with `go-version-file: 'go.mod'`
- Affects: `ghcr-publish.yml` (was stale at 1.23), `test.yml`, `smoke.yml`, `smoke-extra.yml`, `gofmt.yml`, `release.yml`
- Add `renovate.json` to enable automated Go and gomod patch-level automerge
- `dependabot.yml` already covers `gomod` and `github-actions` — no changes needed

## Test plan

- [x] `go build ./cmd/nebula-cert` passes locally
- [x] `go test ./...` passes locally (all packages pass, no failures)
- [ ] CI workflows pass on this PR