### PR TITLE
enable Renovate platformAutomerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "platformAutomerge": true,
   "golang": {
     "enabled": true
   },


### PR DESCRIPTION
Add `platformAutomerge: true` to renovate.json so Renovate uses GitHub's auto-merge feature for approved dependency updates.